### PR TITLE
Changing cache policy and docker config

### DIFF
--- a/docker/config/nginx/nginx.conf
+++ b/docker/config/nginx/nginx.conf
@@ -89,6 +89,7 @@ http {
 		location /image {
             alias /backend/image;
             try_files $uri $uri/ =404;
+			add_header Cache-Control "public, no-cache";
 		}
 
         location /ws/ {

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -75,6 +75,7 @@ services:
       - postgres
     networks:
       - transcendence
+    restart: on-failure:5
 
 networks:
   transcendence:


### PR DESCRIPTION
nginx images endpoint will now add no-cache policy to the header; Asking the client to validate if the image changed and if it did, download it again. If its not the case, it will use the cache

also changed docker config to restart the backend if it bugged (Usually when we delete the db and postgres start too slow)